### PR TITLE
Frontend: add budget comparison widget

### DIFF
--- a/spendwise-front/src/pages/DashboardPage.jsx
+++ b/spendwise-front/src/pages/DashboardPage.jsx
@@ -33,6 +33,7 @@ import {
   updateExpense,
   deleteExpense,
   getAlerts,
+  getAlertStatuses,
   dismissAlert,
   exportExpensesToCSV,
 } from "../services/expenseService";
@@ -187,6 +188,10 @@ export default function DashboardPage() {
   const [editCategorySubmitting, setEditCategorySubmitting] = useState(false);
 
   const [alerts, setAlerts] = useState([]);
+  const [showBudgetComparison, setShowBudgetComparison] = useState(false);
+  const [alertStatuses, setAlertStatuses] = useState([]);
+  const [loadingAlertStatuses, setLoadingAlertStatuses] = useState(false);
+  const [alertStatusError, setAlertStatusError] = useState("");
 
   const loadAlerts = useCallback(async () => {
     try {
@@ -196,6 +201,20 @@ export default function DashboardPage() {
       setAlerts([]);
     }
   }, [token]);
+
+  const loadAlertStatuses = useCallback(async () => {
+    setLoadingAlertStatuses(true);
+    setAlertStatusError("");
+    try {
+      const data = await getAlertStatuses(token, { month, year });
+      setAlertStatuses(data);
+    } catch (err) {
+      setAlertStatuses([]);
+      setAlertStatusError(err.message || "Budget comparison could not be loaded.");
+    } finally {
+      setLoadingAlertStatuses(false);
+    }
+  }, [token, month, year]);
 
   const [settingsFullName, setSettingsFullName] = useState("");
   const [settingsCurrency, setSettingsCurrency] = useState("");
@@ -307,6 +326,12 @@ export default function DashboardPage() {
     fetchSummary();
   }, [fetchSummary]);
 
+  useEffect(() => {
+    if (showBudgetComparison) {
+      loadAlertStatuses();
+    }
+  }, [showBudgetComparison, loadAlertStatuses]);
+
   /**
    * Sign the user out (both server-side and locally via the auth
    * context) and bounce back to the login page.
@@ -374,6 +399,7 @@ export default function DashboardPage() {
       setPaymentMethod("cash");
       await loadDashboardData();
       await fetchSummary();
+      if (showBudgetComparison) await loadAlertStatuses();
     } catch (err) {
       setFormError(err.message);
     } finally {
@@ -394,6 +420,7 @@ export default function DashboardPage() {
       await deleteExpense(token, id);
       await loadDashboardData();
       await fetchSummary();
+      if (showBudgetComparison) await loadAlertStatuses();
     } catch {
       // Best-effort: swallow network glitches so the UI stays responsive.
     }
@@ -450,6 +477,7 @@ export default function DashboardPage() {
       );
       await loadDashboardData();
       await fetchSummary();
+      if (showBudgetComparison) await loadAlertStatuses();
       closeEdit();
     } catch (err) {
       setEditError(err.message);
@@ -565,15 +593,12 @@ export default function DashboardPage() {
 
   // Compute Quick Stats from local expenses array
   const monthTotal = analytics.month_total;
-  const selectedRangeDays = startDate && endDate
-    ? Math.max(1, Math.round((new Date(endDate) - new Date(startDate)) / (1000 * 60 * 60 * 24)) + 1)
-    : now.getDate();
-  const dailyAverage = monthTotal / selectedRangeDays;
 
   const monthLabel = startDate && endDate ? `${startDate} to ${endDate}` :
     startDate ? `From ${startDate}` :
     endDate ? `Until ${endDate}` :
     now.toLocaleString("en-US", { month: "long", year: "numeric" });
+  const formatMoney = (value) => `${Number(value || 0).toFixed(2)} ${user?.currency || "EUR"}`;
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -679,30 +704,39 @@ export default function DashboardPage() {
             <section className="bg-white rounded-2xl border border-gray-200 shadow-sm p-6 space-y-4">
               <div className="flex items-center justify-between">
                 <h3 className="text-sm font-semibold text-gray-700">Quick Stats</h3>
-                <div className="flex gap-2">
-                  <select
-                    value={month}
-                    onChange={(e) => setMonth(parseInt(e.target.value, 10))}
-                    className="border border-gray-300 rounded-md text-sm py-1 px-2 focus:ring-indigo-500 focus:border-indigo-500"
+                <div className="flex flex-wrap justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setShowBudgetComparison((prev) => !prev)}
+                    className="rounded-md border border-indigo-200 bg-indigo-50 px-3 py-1 text-sm font-medium text-indigo-700 hover:bg-indigo-100 transition-colors"
                   >
-                    {Array.from({ length: 12 }, (_, i) => i + 1).map((itemMonth) => {
-                      const date = new Date(2000, itemMonth - 1, 1);
-                      return (
-                        <option key={itemMonth} value={itemMonth}>
-                          {date.toLocaleString("default", { month: "long" })}
-                        </option>
-                      );
-                    })}
-                  </select>
-                  <select
-                    value={year}
-                    onChange={(e) => setYear(parseInt(e.target.value, 10))}
-                    className="border border-gray-300 rounded-md text-sm py-1 px-2 focus:ring-indigo-500 focus:border-indigo-500"
-                  >
-                    {[now.getFullYear() - 1, now.getFullYear(), now.getFullYear() + 1].map((itemYear) => (
-                      <option key={itemYear} value={itemYear}>{itemYear}</option>
-                    ))}
-                  </select>
+                    {showBudgetComparison ? "Hide budget comparison" : "Show budget comparison"}
+                  </button>
+                  <div className="flex gap-2">
+                    <select
+                      value={month}
+                      onChange={(e) => setMonth(parseInt(e.target.value, 10))}
+                      className="border border-gray-300 rounded-md text-sm py-1 px-2 focus:ring-indigo-500 focus:border-indigo-500"
+                    >
+                      {Array.from({ length: 12 }, (_, i) => i + 1).map((itemMonth) => {
+                        const date = new Date(2000, itemMonth - 1, 1);
+                        return (
+                          <option key={itemMonth} value={itemMonth}>
+                            {date.toLocaleString("default", { month: "long" })}
+                          </option>
+                        );
+                      })}
+                    </select>
+                    <select
+                      value={year}
+                      onChange={(e) => setYear(parseInt(e.target.value, 10))}
+                      className="border border-gray-300 rounded-md text-sm py-1 px-2 focus:ring-indigo-500 focus:border-indigo-500"
+                    >
+                      {[now.getFullYear() - 1, now.getFullYear(), now.getFullYear() + 1].map((itemYear) => (
+                        <option key={itemYear} value={itemYear}>{itemYear}</option>
+                      ))}
+                    </select>
+                  </div>
                 </div>
               </div>
 
@@ -720,6 +754,103 @@ export default function DashboardPage() {
                   </div>
                 </section>
               </div>
+
+              {showBudgetComparison && (
+                <section className="rounded-xl border border-gray-200 bg-gray-50 p-4">
+                  <div className="flex items-center justify-between gap-3 mb-4">
+                    <div>
+                      <h3 className="text-sm font-semibold text-gray-800">Budget comparison</h3>
+                      <p className="text-xs text-gray-500">
+                        Real spending against monthly limits for {month}/{year}.
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={loadAlertStatuses}
+                      disabled={loadingAlertStatuses}
+                      className="text-xs font-medium text-indigo-600 hover:text-indigo-700 disabled:opacity-50"
+                    >
+                      {loadingAlertStatuses ? "Refreshing..." : "Refresh"}
+                    </button>
+                  </div>
+
+                  {loadingAlertStatuses ? (
+                    <p className="text-sm text-gray-400 text-center py-6">Loading budget comparison...</p>
+                  ) : alertStatusError ? (
+                    <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-lg">{alertStatusError}</p>
+                  ) : alertStatuses.length === 0 ? (
+                    <p className="text-sm text-gray-400 text-center py-6">
+                      No monthly limits found for this period.
+                    </p>
+                  ) : (
+                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+                      {alertStatuses.map((status) => {
+                        const spent = Number(status.spent_amount || 0);
+                        const limit = Number(status.limit_amount || 0);
+                        const progress = limit > 0 ? Math.min((spent / limit) * 100, 100) : 0;
+                        const accentColor = status.category_color || (status.is_over_limit ? "#DC2626" : "#059669");
+
+                        return (
+                          <article
+                            key={status.id}
+                            className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm"
+                          >
+                            <div className="flex items-start justify-between gap-3">
+                              <div className="flex items-center gap-3 min-w-0">
+                                <span
+                                  className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-lg"
+                                  style={{ backgroundColor: `${accentColor}1A`, color: accentColor }}
+                                >
+                                  {status.category_icon || "💰"}
+                                </span>
+                                <div className="min-w-0">
+                                  <h4 className="text-sm font-semibold text-gray-900 truncate">
+                                    {status.category_name || "Overall budget"}
+                                  </h4>
+                                  <p className="text-xs text-gray-500">
+                                    Limit {formatMoney(status.limit_amount)}
+                                  </p>
+                                </div>
+                              </div>
+                              <span className={`rounded-full px-2 py-1 text-xs font-semibold ${
+                                status.is_over_limit
+                                  ? "bg-red-50 text-red-700"
+                                  : "bg-emerald-50 text-emerald-700"
+                              }`}>
+                                {status.is_over_limit ? "Exceeded" : "OK"}
+                              </span>
+                            </div>
+
+                            <div className="mt-4 h-2 overflow-hidden rounded-full bg-gray-100">
+                              <div
+                                className={status.is_over_limit ? "h-full bg-red-500" : "h-full bg-emerald-500"}
+                                style={{ width: `${progress}%` }}
+                              />
+                            </div>
+
+                            <div className="mt-4 grid grid-cols-3 gap-2 text-xs">
+                              <div>
+                                <p className="text-gray-400">Spent</p>
+                                <p className="font-semibold text-gray-900">{formatMoney(status.spent_amount)}</p>
+                              </div>
+                              <div>
+                                <p className="text-gray-400">Remaining</p>
+                                <p className={status.remaining_amount < 0 ? "font-semibold text-red-600" : "font-semibold text-gray-900"}>
+                                  {formatMoney(status.remaining_amount)}
+                                </p>
+                              </div>
+                              <div>
+                                <p className="text-gray-400">Status</p>
+                                <p className="font-semibold text-gray-900">{status.status}</p>
+                              </div>
+                            </div>
+                          </article>
+                        );
+                      })}
+                    </div>
+                  )}
+                </section>
+              )}
             </section>
 
             {/* Filters */}

--- a/spendwise-front/src/pages/DashboardPage.jsx
+++ b/spendwise-front/src/pages/DashboardPage.jsx
@@ -713,11 +713,12 @@ export default function DashboardPage() {
                       aria-checked={showBudgetComparison}
                       aria-label="Budget comparison"
                       onClick={() => setShowBudgetComparison((prev) => !prev)}
-                      className={`relative inline-flex h-10 w-20 shrink-0 items-center rounded-full border transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 ${
+                      className={`relative inline-flex h-10 w-20 shrink-0 items-center overflow-hidden border transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 ${
                         showBudgetComparison
                           ? "border-emerald-400 bg-emerald-400"
                           : "border-gray-300 bg-gray-200"
                       }`}
+                      style={{ borderRadius: "9999px" }}
                     >
                       <span
                         className={`inline-block h-9 w-9 transform rounded-full bg-white shadow-md transition-transform duration-200 ${

--- a/spendwise-front/src/pages/DashboardPage.jsx
+++ b/spendwise-front/src/pages/DashboardPage.jsx
@@ -713,15 +713,15 @@ export default function DashboardPage() {
                       aria-checked={showBudgetComparison}
                       aria-label="Budget comparison"
                       onClick={() => setShowBudgetComparison((prev) => !prev)}
-                      className={`relative inline-flex h-8 w-16 shrink-0 items-center rounded-full border transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 ${
+                      className={`relative inline-flex h-10 w-20 shrink-0 items-center rounded-full border transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 ${
                         showBudgetComparison
                           ? "border-emerald-400 bg-emerald-400"
                           : "border-gray-300 bg-gray-200"
                       }`}
                     >
                       <span
-                        className={`inline-block h-7 w-7 transform rounded-full bg-white shadow-md transition-transform duration-200 ${
-                          showBudgetComparison ? "translate-x-8" : "translate-x-0.5"
+                        className={`inline-block h-9 w-9 transform rounded-full bg-white shadow-md transition-transform duration-200 ${
+                          showBudgetComparison ? "translate-x-10" : "translate-x-0.5"
                         }`}
                       />
                     </button>

--- a/spendwise-front/src/pages/DashboardPage.jsx
+++ b/spendwise-front/src/pages/DashboardPage.jsx
@@ -705,13 +705,27 @@ export default function DashboardPage() {
               <div className="flex items-center justify-between">
                 <h3 className="text-sm font-semibold text-gray-700">Quick Stats</h3>
                 <div className="flex flex-wrap justify-end gap-2">
-                  <button
-                    type="button"
-                    onClick={() => setShowBudgetComparison((prev) => !prev)}
-                    className="rounded-md border border-indigo-200 bg-indigo-50 px-3 py-1 text-sm font-medium text-indigo-700 hover:bg-indigo-100 transition-colors"
-                  >
-                    {showBudgetComparison ? "Hide budget comparison" : "Show budget comparison"}
-                  </button>
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-gray-600">Budget comparison</span>
+                    <button
+                      type="button"
+                      role="switch"
+                      aria-checked={showBudgetComparison}
+                      aria-label="Budget comparison"
+                      onClick={() => setShowBudgetComparison((prev) => !prev)}
+                      className={`relative inline-flex h-8 w-16 shrink-0 items-center rounded-full border transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 ${
+                        showBudgetComparison
+                          ? "border-emerald-400 bg-emerald-400"
+                          : "border-gray-300 bg-gray-200"
+                      }`}
+                    >
+                      <span
+                        className={`inline-block h-7 w-7 transform rounded-full bg-white shadow-md transition-transform duration-200 ${
+                          showBudgetComparison ? "translate-x-8" : "translate-x-0.5"
+                        }`}
+                      />
+                    </button>
+                  </div>
                   <div className="flex gap-2">
                     <select
                       value={month}

--- a/spendwise-front/src/pages/DashboardPage.test.jsx
+++ b/spendwise-front/src/pages/DashboardPage.test.jsx
@@ -169,7 +169,7 @@ describe('DashboardPage', () => {
 
     expect(screen.queryByText(/real spending against monthly limits/i)).not.toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: /show budget comparison/i }))
+    await user.click(screen.getByRole('switch', { name: /budget comparison/i }))
 
     await waitFor(() => {
       expect(expenseService.getAlertStatuses).toHaveBeenCalledWith('tok', expect.objectContaining({
@@ -188,7 +188,7 @@ describe('DashboardPage', () => {
     const user = userEvent.setup()
     renderPage()
 
-    await user.click(screen.getByRole('button', { name: /show budget comparison/i }))
+    await user.click(screen.getByRole('switch', { name: /budget comparison/i }))
 
     expect(await screen.findByText(/no monthly limits found/i)).toBeInTheDocument()
   })
@@ -198,7 +198,7 @@ describe('DashboardPage', () => {
     const user = userEvent.setup()
     renderPage()
 
-    await user.click(screen.getByRole('button', { name: /show budget comparison/i }))
+    await user.click(screen.getByRole('switch', { name: /budget comparison/i }))
 
     expect(await screen.findByText('comparison unavailable')).toBeInTheDocument()
   })

--- a/spendwise-front/src/pages/DashboardPage.test.jsx
+++ b/spendwise-front/src/pages/DashboardPage.test.jsx
@@ -18,6 +18,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
+import * as expenseService from '../services/expenseService'
 
 // Replace Recharts' ResponsiveContainer with a div that simply renders
 // its children. The real component measures its parent and bails out
@@ -56,6 +57,10 @@ vi.mock('../services/expenseService', () => ({
   createExpense: vi.fn(),
   updateExpense: vi.fn(),
   deleteExpense: vi.fn(),
+  getAlerts: vi.fn().mockResolvedValue([]),
+  getAlertStatuses: vi.fn().mockResolvedValue([]),
+  dismissAlert: vi.fn(),
+  exportExpensesToCSV: vi.fn(),
 }))
 
 const mockNavigate = vi.fn()
@@ -126,5 +131,75 @@ describe('DashboardPage', () => {
       expect(mockLogout).toHaveBeenCalled()
     })
     expect(mockNavigate).toHaveBeenCalledWith('/login')
+  })
+
+  it('loads and renders the budget comparison widget when enabled', async () => {
+    expenseService.getAlertStatuses.mockResolvedValueOnce([
+      {
+        id: 1,
+        category_id: 2,
+        category_name: 'Food',
+        category_icon: '🍔',
+        category_color: '#f97316',
+        month: 1,
+        year: 2026,
+        limit_amount: 200,
+        spent_amount: 120,
+        remaining_amount: 80,
+        status: 'ok',
+        is_over_limit: false,
+      },
+      {
+        id: 2,
+        category_id: null,
+        category_name: null,
+        category_icon: null,
+        category_color: null,
+        month: 1,
+        year: 2026,
+        limit_amount: 300,
+        spent_amount: 340,
+        remaining_amount: -40,
+        status: 'exceeded',
+        is_over_limit: true,
+      },
+    ])
+    const user = userEvent.setup()
+    renderPage()
+
+    expect(screen.queryByText(/real spending against monthly limits/i)).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /show budget comparison/i }))
+
+    await waitFor(() => {
+      expect(expenseService.getAlertStatuses).toHaveBeenCalledWith('tok', expect.objectContaining({
+        month: expect.any(Number),
+        year: expect.any(Number),
+      }))
+    })
+    expect(await screen.findByText('Food')).toBeInTheDocument()
+    expect(screen.getByText('Overall budget')).toBeInTheDocument()
+    expect(screen.getByText('OK')).toBeInTheDocument()
+    expect(screen.getByText('Exceeded')).toBeInTheDocument()
+  })
+
+  it('shows an empty state when the budget comparison returns no statuses', async () => {
+    expenseService.getAlertStatuses.mockResolvedValueOnce([])
+    const user = userEvent.setup()
+    renderPage()
+
+    await user.click(screen.getByRole('button', { name: /show budget comparison/i }))
+
+    expect(await screen.findByText(/no monthly limits found/i)).toBeInTheDocument()
+  })
+
+  it('shows an inline error when the budget comparison request fails', async () => {
+    expenseService.getAlertStatuses.mockRejectedValueOnce(new Error('comparison unavailable'))
+    const user = userEvent.setup()
+    renderPage()
+
+    await user.click(screen.getByRole('button', { name: /show budget comparison/i }))
+
+    expect(await screen.findByText('comparison unavailable')).toBeInTheDocument()
   })
 })

--- a/spendwise-front/src/services/expenseService.js
+++ b/spendwise-front/src/services/expenseService.js
@@ -364,6 +364,22 @@ export async function getDashboardSummary(token, { month, year } = {}) {
  */
 
 /**
+ * @typedef {Object} AlertStatus
+ * @property {number} id - Budget primary key.
+ * @property {number|null} category_id - Category the budget applies to, or `null` for an overall budget.
+ * @property {string|null} category_name - Category display name.
+ * @property {string|null} category_icon - Category icon.
+ * @property {string|null} category_color - Category colour.
+ * @property {number} month - Budget month.
+ * @property {number} year - Budget year.
+ * @property {number} limit_amount - User-defined monthly limit.
+ * @property {number} spent_amount - Real spending for the same period.
+ * @property {number} remaining_amount - Difference between limit and spending.
+ * @property {string} status - Backend status, e.g. `"ok"` or `"exceeded"`.
+ * @property {boolean} is_over_limit - Whether spending is above the limit.
+ */
+
+/**
  * Fetch all pending alerts for the authenticated user, newest first.
  *
  * @param {string} token - Bearer token.
@@ -376,6 +392,29 @@ export async function getAlerts(token) {
   });
   const data = await res.json();
   if (!res.ok) throw new Error(data.detail || "Failed to fetch alerts");
+  return data;
+}
+
+/**
+ * Fetch budget-vs-spending statuses for the authenticated user.
+ *
+ * @param {string} token - Bearer token.
+ * @param {Object} [filters] - Optional period filters. Defaults server-side to the current period.
+ * @param {number} [filters.month] - Month filter (1..12).
+ * @param {number} [filters.year] - Year filter.
+ * @returns {Promise<AlertStatus[]>}
+ * @throws {Error} If the backend errors out.
+ */
+export async function getAlertStatuses(token, { month, year } = {}) {
+  const params = new URLSearchParams();
+  if (month) params.set("month", month);
+  if (year) params.set("year", year);
+
+  const res = await fetch(`${API_BASE}/alerts/statuses?${params}`, {
+    headers: authHeaders(token),
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(data.detail || "Failed to fetch budget comparison");
   return data;
 }
 

--- a/spendwise-front/src/services/expenseService.test.js
+++ b/spendwise-front/src/services/expenseService.test.js
@@ -21,6 +21,7 @@ import {
   updateExpense,
   deleteExpense,
   getDashboardSummary,
+  getAlertStatuses,
   exportExpensesToCSV,
 } from './expenseService'
 
@@ -283,6 +284,43 @@ describe('expenseService', () => {
       expect(result).toEqual(summary)
       const [url] = fetch.mock.calls[0]
       expect(url).toContain('/dashboard/summary?')
+    })
+  })
+
+  describe('getAlertStatuses()', () => {
+    it('fetches budget comparison statuses for the requested period', async () => {
+      const statuses = [
+        {
+          id: 1,
+          category_id: 2,
+          category_name: 'Food',
+          month: 4,
+          year: 2026,
+          limit_amount: 200,
+          spent_amount: 120,
+          remaining_amount: 80,
+          status: 'ok',
+          is_over_limit: false,
+        },
+      ]
+      fetch.mockResolvedValueOnce(fakeResponse({ body: statuses }))
+
+      const result = await getAlertStatuses('tok', { month: 4, year: 2026 })
+
+      expect(result).toEqual(statuses)
+      const [url, init] = fetch.mock.calls[0]
+      expect(url).toContain('/alerts/statuses?')
+      expect(url).toContain('month=4')
+      expect(url).toContain('year=2026')
+      expect(init.headers.Authorization).toBe('Bearer tok')
+    })
+
+    it('throws when the backend rejects the request', async () => {
+      fetch.mockResolvedValueOnce(
+        fakeResponse({ ok: false, status: 500, body: { detail: 'comparison unavailable' } }),
+      )
+
+      await expect(getAlertStatuses('tok', { month: 4, year: 2026 })).rejects.toThrow('comparison unavailable')
     })
   })
 


### PR DESCRIPTION
## Summary
- Adds a frontend client for `GET /api/v1/alerts/statuses`.
- Adds an activable dashboard widget that compares real spending against monthly limits.
- Adds service and dashboard tests for the new budget comparison flow.

## Verification
- `npx eslint src/pages/DashboardPage.jsx src/services/expenseService.js src/pages/DashboardPage.test.jsx src/services/expenseService.test.js`
- `npx vitest run src/services/expenseService.test.js --environment node -t getAlertStatuses`
- `npm run build`

## Notes
- Full `npm test -- --run` is currently blocked before executing tests by a jsdom dependency error: `ERR_REQUIRE_ESM` from `html-encoding-sniffer` requiring `@exodus/bytes/encoding-lite.js`.
- Full `npm run lint` still reports pre-existing issues outside this feature in `AuthContext.jsx` and `RegisterPage.test.jsx`.

Closes #84
References #41 and #83